### PR TITLE
do not send message to telegram API during the migration

### DIFF
--- a/src/jung2botUtil.js
+++ b/src/jung2botUtil.js
@@ -1,19 +1,20 @@
-import axios from 'axios'
-import Pino from 'pino'
+// import axios from 'axios'
+// import Pino from 'pino'
 
 export default class jung2botUtil {
-  constructor () {
-    this.logger = new Pino({ level: process.env.LOG_LEVEL })
-  }
+  // constructor () {
+  //   this.logger = new Pino({ level: process.env.LOG_LEVEL })
+  // }
   async sendMessage (chatId, message) {
     // TODO: TELEGRAM_BOT_TOKEN should be loaded from SSM Parameter Store
-    const url = `https://api.telegram.org/bot${process.env.TELEGRAM_BOT_TOKEN}/sendMessage`
-    const data = {
-      chat_id: chatId,
-      text: message
-    }
-    const response = axios.post(url, data)
-    this.logger.debug('response', response)
-    return response
+    // const url = `https://api.telegram.org/bot${process.env.TELEGRAM_BOT_TOKEN}/sendMessage`
+    // const data = {
+    //   chat_id: chatId,
+    //   text: message
+    // }
+    // const response = axios.post(url, data)
+    // this.logger.debug('response', response)
+    // return response
+    return true
   }
 }

--- a/test/testHelp.js
+++ b/test/testHelp.js
@@ -8,7 +8,7 @@ import dotenv from 'dotenv'
 
 dotenv.config({ path: path.resolve(__dirname, '.env.testing') })
 
-test('sendHelpMessage', async t => {
+test.failing('sendHelpMessage', async t => {
   nock(`https://api.telegram.org/bot${process.env.TELEGRAM_BOT_TOKEN}`)
     .post('/sendMessage')
     .reply(200, {

--- a/test/testJung2botUtil.js
+++ b/test/testJung2botUtil.js
@@ -8,7 +8,7 @@ dotenv.config({ path: path.resolve(__dirname, '.env.testing') })
 
 const jung2botUtil = new Jung2botUtil()
 
-test('sendMessage', async t => {
+test.failing('sendMessage', async t => {
   nock(`https://api.telegram.org/bot${process.env.TELEGRAM_BOT_TOKEN}`)
     .post('/sendMessage')
     .reply(200, {
@@ -20,7 +20,7 @@ test('sendMessage', async t => {
   nock.restore()
 })
 
-test('sendMessage - failing - Telegram API returns HTTP 400 Error', async t => {
+test.failing('sendMessage - failing - Telegram API returns HTTP 400 Error', async t => {
   nock(`https://api.telegram.org/bot${process.env.TELEGRAM_BOT_TOKEN}`)
     .post('/sendMessage')
     .reply(400)

--- a/test/testOffFromWork.js
+++ b/test/testOffFromWork.js
@@ -32,7 +32,7 @@ test.serial('off', async t => {
   nock.restore()
 })
 
-test.serial('off - with error', async t => {
+test.serial.failing('off - with error', async t => {
   nock(`https://api.telegram.org/bot${process.env.TELEGRAM_BOT_TOKEN}`)
     .persist()
     .post('/sendMessage')

--- a/test/testStatistics.js
+++ b/test/testStatistics.js
@@ -70,7 +70,7 @@ test('/alljung', async t => {
   nock.restore()
 })
 
-test.serial('/topten with error', async t => {
+test.serial.failing('/topten with error', async t => {
   const statistics = new Statistics()
   try {
     await statistics.topTen(stubTopTen.message)


### PR DESCRIPTION
As the first part of the migration, do not send message to telegram API during the migration, #76