### PR TITLE
ci: stop test.yaml running twice per commit

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -2,7 +2,13 @@ name: Test
 
 on:
   push:
+    branches: [master]
   pull_request:
+    branches: [master]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   # Run on arm64. Buck2 latest cannot link Go 1.27 stdlib on linux/amd64:


### PR DESCRIPTION
Unfiltered push/pull_request triggers meant every push to a branch with an open PR ran the same tests twice. Restricts push to master and adds a concurrency group, matching claude.yaml's pattern.