### PR TITLE
chore: add renovate config, adapted from otaru

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -1,0 +1,12 @@
+{
+  $schema: 'https://docs.renovatebot.com/renovate-schema.json',
+  extends: [
+    'config:best-practices',
+  ],
+  automerge: true,
+  major: {
+    automerge: false,
+  },
+  minimumReleaseAge: '7 days',
+  rebaseWhen: 'behind-base-branch',
+}


### PR DESCRIPTION
This repo has had no renovate config since the JS-era one moved to .scratchpad/legacy/ with the rest of the JS tree. Adopts otaru's base structure (config:best-practices, automerge minor/patch, 7-day release age, rebase when behind) without otaru's repo-specific packageRules (Home Assistant, terragrunt/chart-releaser/yq actions - none of which apply here).