### PR TITLE
chore(renovate): don't flag go.uber.org/mock as abandoned

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -9,4 +9,12 @@
   },
   minimumReleaseAge: '7 days',
   rebaseWhen: 'behind-base-branch',
+  packageRules: [
+    {
+      matchPackageNames: [
+        'go.uber.org/mock',
+      ],
+      abandonmentThreshold: null,
+    },
+  ],
 }


### PR DESCRIPTION
Renovate flagged it as abandoned purely on release-inactivity heuristics. It's actively maintained. Same pattern otaru already uses for known-fine-but-flagged packages.