### PR TITLE
Harden Telegram errors and container build input

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,8 +1,13 @@
-.git
-buck-out
-.scratchpad
-node_modules
-vendor
-.env.development
-.env.production
-.env.ecs
+# Send only the files required for the production Go build.
+**
+!go.mod
+!go.sum
+!cmd/
+!cmd/**
+!internal/
+!internal/**
+
+# Tests and generated mocks do not contribute to the production binary.
+**/*_test.go
+internal/integration/
+internal/mock/

--- a/.github/workflows/build-image-jung2bot.yml
+++ b/.github/workflows/build-image-jung2bot.yml
@@ -43,7 +43,6 @@ jobs:
         uses: docker/metadata-action@dc802804100637a589fabce1cb79ff13a1411302 # v6.2.0
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
-          # Go and JS share this repository, so never move latest.
           flavor: latest=false
 
       - name: Build and push

--- a/.github/workflows/build-image-jung2bot.yml
+++ b/.github/workflows/build-image-jung2bot.yml
@@ -43,7 +43,6 @@ jobs:
         uses: docker/metadata-action@dc802804100637a589fabce1cb79ff13a1411302 # v6.2.0
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
-          flavor: latest=false
 
       - name: Build and push
         uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0

--- a/.gitignore
+++ b/.gitignore
@@ -13,9 +13,6 @@
 coverage/
 vendor
 
-# Node
-node_modules/
-
 # Logs
 logs/
 *.log

--- a/.markdownlint-cli2.jsonc
+++ b/.markdownlint-cli2.jsonc
@@ -2,7 +2,6 @@
   "globs": [
     "**/*.md",
     "!buck-out/**",
-    "!node_modules/**",
     "!.scratchpad/**",
     "!vendor/**"
   ],

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -90,6 +90,9 @@ focused Go tests.
 - Use Buck2's official `prelude//go/tools/gobuckify:gobuckify` target for Go
   vendor BUCK generation through `make vendor`; do not reintroduce a custom
   generator.
+- The project supports Docker and Apple Container image builds. For local image
+  validation, use Apple Container (`container build`) first when it is
+  available. Use Docker when Apple Container is unavailable.
 - Create agent worktrees outside this repo's directory tree (e.g. `/tmp/...`),
   not nested inside it (e.g. `.scratchpad/worktrees/...`). A worktree nested
   inside the repo makes Buck2 resolve the wrong root and fail with

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,8 @@ ARG TARGETARCH
 WORKDIR /app
 COPY go.mod go.sum ./
 RUN go mod download
-COPY . ./
+COPY cmd ./cmd
+COPY internal ./internal
 RUN CGO_ENABLED=0 GOOS=linux GOARCH=$TARGETARCH go build -o /out/telegram-jung2-bot ./cmd
 
 FROM gcr.io/distroless/static-debian12:nonroot@sha256:afa5c872c891853ca7fcf1f12c3edb23f7eeef36189728842dd51042ff57f7ab

--- a/hack/lint.sh
+++ b/hack/lint.sh
@@ -17,7 +17,6 @@ done < <(find . \
   -name '*.go' \
   -not -path './buck-out/*' \
   -not -path './internal/mock/*' \
-  -not -path './node_modules/*' \
   -not -path './vendor/*' \
   | sort)
 
@@ -28,7 +27,6 @@ done < <(find . \
   -type f \
   -name '*.sh' \
   -not -path './buck-out/*' \
-  -not -path './node_modules/*' \
   -not -path './vendor/*' \
   | sort)
 

--- a/internal/telegram.go
+++ b/internal/telegram.go
@@ -258,10 +258,23 @@ func (client Client) do(
 
 	response, err := client.httpClient.Do(request)
 	if err != nil {
-		return nil, fmt.Errorf("call Telegram %s: %w", endpoint, err)
+		return nil, telegramTransportError(endpoint, err)
 	}
 
 	return response, nil
+}
+
+// telegramTransportError retains useful request state without exposing the bot token in a request URL.
+// For example, a cancelled request becomes "call Telegram sendMessage: request cancelled".
+func telegramTransportError(endpoint string, err error) error {
+	switch {
+	case errors.Is(err, context.Canceled):
+		return fmt.Errorf("call Telegram %s: request cancelled", endpoint)
+	case errors.Is(err, context.DeadlineExceeded):
+		return fmt.Errorf("call Telegram %s: request timed out", endpoint)
+	default:
+		return fmt.Errorf("call Telegram %s: transport request failed", endpoint)
+	}
 }
 
 // telegramAPIError converts non-2xx responses into errors.

--- a/internal/telegram_test.go
+++ b/internal/telegram_test.go
@@ -169,6 +169,26 @@ func TestSendMessageRedactsTokenFromTransportError(t *testing.T) {
 	assert.NotContains(t, err.Error(), botToken)
 }
 
+// TestTelegramTransportErrorClassifiesContextErrors keeps cancellation details safe and actionable.
+func TestTelegramTransportErrorClassifiesContextErrors(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		err  error
+		want string
+	}{
+		{name: "cancelled", err: context.Canceled, want: "call Telegram sendMessage: request cancelled"},
+		{name: "timed out", err: context.DeadlineExceeded, want: "call Telegram sendMessage: request timed out"},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			assert.EqualError(t, telegramTransportError("sendMessage", test.err), test.want)
+		})
+	}
+}
+
 func TestGetChatAdministratorsDecodesResponse(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(response http.ResponseWriter, request *http.Request) {
 		assert.Equal(t, "/bottoken/getChatAdministrators", request.URL.Path)

--- a/internal/telegram_test.go
+++ b/internal/telegram_test.go
@@ -156,13 +156,17 @@ func TestSendMessageReturnsRequestCreationError(t *testing.T) {
 	assert.Contains(t, err.Error(), "create Telegram sendMessage request")
 }
 
-func TestSendMessageReturnsHTTPClientError(t *testing.T) {
-	client := NewClient("token", WithHTTPClient(&http.Client{Transport: failingRoundTripper{}}))
+// TestSendMessageRedactsTokenFromTransportError proves transport failures cannot disclose the bot token through logs.
+func TestSendMessageRedactsTokenFromTransportError(t *testing.T) {
+	const botToken = "secret-token"
+	client := NewClient(botToken, WithHTTPClient(&http.Client{Transport: failingRoundTripper{}}))
 
 	err := client.SendMessage(context.Background(), 123, "hi")
 
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "call Telegram sendMessage")
+	assert.Contains(t, err.Error(), "transport request failed")
+	assert.NotContains(t, err.Error(), botToken)
 }
 
 func TestGetChatAdministratorsDecodesResponse(t *testing.T) {


### PR DESCRIPTION
## Summary
- redact token-bearing Telegram transport errors
- minimise the container build context to production Go inputs
- remove stale Node project handling and document Apple Container validation

## Validation
- make test
- container build --no-cache --arch arm64 --tag telegram-jung2-bot:security-review --file Dockerfile .