### PR TITLE
docs: make AGENTS.md and README architecture scannable

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,107 +1,72 @@
 # Agent Instructions
 
-This repository is the Go service for `telegram-jung2-bot`. Keep the root
-clean, Go-native, and contract-first. Production behaviour is preserved by
-focused Go tests.
+Go service for `telegram-jung2-bot`. The executable lives in `cmd/`. Private
+packages live in `internal/`. Do not create a `go/` directory. Preserve
+production contracts with focused Go tests.
 
-## Working Rules
+## Commands
 
-- Work on independent modules first; keep app wiring behind stable package
-  contracts and tests.
-- Do not create a `go/` subdirectory. The service executable lives under
-  `cmd/`; private Go packages live under `internal/`.
-- Keep Buck target visibility explicit even though the Go `internal` import
-  rule also prevents imports from outside this module tree.
-- Do not add shared `testutil`, shared mocks, or abstraction packages until
-  repeated code proves they are needed.
+Do not run native `go test`.
+
+| Task             | Command                                |
+|------------------|----------------------------------------|
+| Local validation | `make test`                            |
+| Coverage         | `make coverage`                        |
+| Mocks            | `make mock`                            |
+| Dependencies     | `make vendor`                          |
+| CI               | `make ci`                              |
+| Local image      | `container build`, else `docker build` |
+
+`make test` is the local gate. It runs lint, then Buck2 tests with the race
+detector. `make test-only` skips lint. CI uses that after one lint job.
+
+`make coverage` must stay at 100% for `internal/`. `cmd/` is excluded.
+
+Run `make vendor` after dependency changes. It uses
+`prelude//go/tools/gobuckify:gobuckify`. Do not add a custom generator.
+
+Local images: use Apple Container first when it is available. Otherwise use
+Docker.
+
+Create worktrees under `/tmp`, not inside this repo. Nested worktrees,
+including `.scratchpad/worktrees/`, make Buck2 use the wrong root. A new
+worktree has no `vendor/`. Symlink it from the main checkout before
+`make test`.
+
+## Layout
+
 - Keep domain packages free of AWS SDK clients, Telegram HTTP clients, HTTP
-  server code, environment readers, and app wiring.
-- Use package-local interfaces, fakes, or generated mocks. Use
-  `go.uber.org/mock` for generated mocks when hand-written fakes become noisy.
+  servers, environment readers, and app wiring.
+- Keep Buck target visibility explicit.
+- Do not add shared `testutil`, shared mocks, or abstraction packages until
+  reuse is proven.
+- After you change a package-local interface, run `make mock`. Generated
+  GoMock lives under `internal/mock/` via `go.uber.org/mock`. Use a
+  hand-written fake only while the generated mock is noisier.
 
-## Contract Rules
+## Contracts
 
-- Preserve DynamoDB table names, key names, attribute names, and value formats.
-- Preserve Telegram command names, aliases, response text, ordering, and
-  truncation behaviour.
-- Preserve SQS action names and support both message attribute casings:
-  `messageAttributes.action.stringValue` and
-  `messageAttributes.action.StringValue`.
-- Preserve existing `dateCreated` parsing for the stored UTC+8 offset format
-  before normalising time internally.
-- Add or update Go tests for production-contract behaviour you touch.
-- Every implementation change should identify the contract test case it
-  preserves.
+Preserve DynamoDB names and `dateCreated` UTC+8 parsing. Preserve Telegram
+command names, aliases, response text, and ordering. Preserve SQS action
+names. Name the contract test that the change preserves.
 
-## Domain Rules
+| Item          | Rule                                                                           |
+|---------------|--------------------------------------------------------------------------------|
+| Workday bits  | `Sun=1`, `Mon=2`, `Tue=4`, `Wed=8`, `Thu=16`, `Fri=32`, `Sat=64`               |
+| MESSAGE_TABLE | Partition `chatId`, sort `dateCreated`, TTL 7 days                             |
+| CHATID_TABLE  | Partition `chatId`. Stores `chatTitle`, `enableAllJung`, `offTime`, `workday`  |
+| Pagination    | Follow `LastEvaluatedKey`                                                      |
+| Reports       | Truncate final rendered reports at 3800 characters. Keep truncation UTF-8 safe |
+| SQS action    | Support `messageAttributes.action.stringValue` and `StringValue`               |
+| Logs          | Do not log Telegram message text                                               |
 
-- Never change the workday bitmask values:
-  `Sun=1`, `Mon=2`, `Tue=4`, `Wed=8`, `Thu=16`, `Fri=32`, `Sat=64`.
-- `MESSAGE_TABLE` uses `chatId` as the partition key and `dateCreated` as the
-  sort key; message TTL is 7 days.
-- `CHATID_TABLE` uses `chatId` as the partition key and stores `chatTitle`,
-  `enableAllJung`, `offTime`, and `workday`.
-- Always handle DynamoDB pagination with `LastEvaluatedKey`.
-- Truncate generated Telegram reports at 3800 characters after rendering final
-  text, and keep truncation UTF-8 safe.
-- Avoid logging unnecessary Telegram message text.
+## Go
 
-## Go Guidance
+When a function transforms, normalises, validates, or derives data, add a
+short docstring example of the input and output shape.
 
-- Use `context.Context` for network, AWS, Telegram, and shutdown-aware
-  operations.
-- Wrap errors with useful context using `%w`.
-- Use `log/slog` for structured logs.
-- Avoid global mutable state except for startup configuration.
-- Keep identifiers unexported unless they are needed outside their own
-  package.
-- Keep package APIs small and stable before depending on them from other
-  packages.
-- When a function transforms, normalises, validates, or derives data, add a
-  short docstring example that shows the input and output shape.
+## Tests
 
-## Build, Test, And Lint
-
-- `make vendor` refreshes Go vendoring and generated Buck targets.
-- `make build` builds the Go service with Buck2.
-- `make ci` runs the full CI gate in order: `vendor`, then `make coverage`
-  (which runs `make test`, and therefore `make lint`, before collecting
-  coverage).
-- Use `make test` for Buck2 test execution and `make coverage` for the Buck-built
-  coverage gate.
-- Do not invoke native `go test` directly for validation.
-- `make test` runs `make lint` first.
-- `make test` runs Buck2 tests with the race detector enabled.
-- `make test-only` is `make test` without lint. Use `make test` locally. CI
-  lints once, then runs `test-only` on arm64.
-- `make coverage` runs only the Buck-built atomic Go coverage gate; coverage
-  must remain 100% for `internal/` packages, and `cmd/` entrypoints are
-  excluded from the coverage gate.
-- `make coverage` reuses the same Buck test target set and race mode as
-  `make test`; test selection lives in the `Makefile`, not the coverage script.
-- `make build` and `make test` do not refresh vendoring; run `make vendor`
-  explicitly after dependency changes.
-- `make lint` runs `gofmt` checks, `go vet`, `golangci-lint`, `shellcheck`,
-  and `markdownlint-cli2`.
-- `make lint-fix` applies supported formatting/lint fixes.
-- `make mock` removes old generated mocks, then regenerates centralised GoMock
-  code under `internal/mock/` via `go generate`.
-- `make install-buck2` installs or updates Buck2 for the local platform.
-- Use Buck2's official `prelude//go/tools/gobuckify:gobuckify` target for Go
-  vendor BUCK generation through `make vendor`; do not reintroduce a custom
-  generator.
-- The project supports Docker and Apple Container image builds. For local image
-  validation, use Apple Container (`container build`) first when it is
-  available. Use Docker when Apple Container is unavailable.
-- Create agent worktrees outside this repo's directory tree (e.g. `/tmp/...`),
-  not nested inside it (e.g. `.scratchpad/worktrees/...`). A worktree nested
-  inside the repo makes Buck2 resolve the wrong root and fail with
-  `set_cfg_constructor() can only be called from the repository root`.
-
-## Test Guidance
-
-- If a package contains real concurrent logic such as goroutines, channels,
-  cancellation coordination, `errgroup`, `sync`, or shared mutable state, its
-  tests must exercise that concurrency so the race detector can observe it.
-- Do not invent concurrency tests for pure parsing, validation, formatting, or
-  data-shaping packages just to satisfy the race detector.
+If a package uses goroutines, channels, or shared mutable state, the tests
+must exercise that concurrency. Do not add concurrency tests for parsers or
+formatters.

--- a/README.md
+++ b/README.md
@@ -27,20 +27,24 @@ chat group.
 ## Architecture
 
 The bot counts group messages, ranks speakers, and sends off-work reports.
-Telegram and the scheduler hit HTTP. HTTP writes DynamoDB and enqueues SQS.
-The worker consumes SQS and calls DynamoDB and Telegram.
+[Telegram](https://core.telegram.org/bots) and the scheduler hit HTTP. HTTP
+writes [DynamoDB](https://aws.amazon.com/dynamodb/) and enqueues
+[SQS](https://aws.amazon.com/sqs/). The worker consumes SQS and calls DynamoDB
+and Telegram.
 
-| Process | Address | Role                                     |
-|---------|---------|------------------------------------------|
-| HTTP    | `:3000` | Webhook, `/health`, and scheduler routes |
-| Metrics | `:9090` | `/metrics`                               |
-| Worker  |         | SQS actions                              |
+| Process | Address | Role                                                                                |
+|---------|---------|-------------------------------------------------------------------------------------|
+| HTTP    | `:3000` | [Webhook](https://core.telegram.org/bots/webhooks), `/health`, and scheduler routes |
+| Metrics | `:9090` | `/metrics`                                                                          |
+| Worker  |         | SQS actions                                                                         |
 
-Code lives in `cmd/` and `internal/`. Buck2 builds and tests.
+Code lives in `cmd/` and `internal/`. [Buck2](https://buck2.build/) builds and
+tests.
 
 ### Metrics
 
-`/metrics` includes Go and process collectors plus:
+[Prometheus](https://prometheus.io/) `/metrics` includes Go and process
+collectors plus:
 
 | Metric                                                   | Meaning                           |
 |----------------------------------------------------------|-----------------------------------|
@@ -62,24 +66,29 @@ HTTP metrics use fixed method, status, and route labels.
 
 This project started in [2016](https://github.com/siutsin/telegram-jung2-bot/pull/1),
 more than a decade ago (!), as my technical
-playground. It was a way to learn Node.js and the Telegram Bot API, and
-to put a meme bot in my Telegram groups. For whatever reason it
-spread, and thousands of groups were using it at that time.
+playground. It was a way to learn [Node.js](https://nodejs.org/) and the
+[Telegram Bot API](https://core.telegram.org/bots/api), and to put a meme bot
+in my Telegram groups. For whatever reason it spread, and thousands of groups
+were using it at that time.
 
-Over time it became a lab for experiments: Heroku, PM2, Serverless Framework,
-AWS ECS, Kubernetes, and more that I cannot even remember. The funny thing
-is that I have not used this bot myself for a very long time.
+Over time it became a lab for experiments:
+[Heroku](https://www.heroku.com/), [PM2](https://pm2.keymetrics.io/),
+[Serverless Framework](https://www.serverless.com/),
+[AWS ECS](https://aws.amazon.com/ecs/), [Kubernetes](https://kubernetes.io/),
+and more that I cannot even remember. The funny thing is that I have not used
+this bot myself for a very long time.
 
 The JavaScript ecosystem has constant supply-chain issues, and the number of
 dependencies and their transitive dependencies is scary. I rewrote the
-service in Go so that it would need almost no maintenance, whilst keeping it
-running until no one is using it.
+service in [Go](https://go.dev/) so that it would need almost no maintenance,
+whilst keeping it running until no one is using it.
 
 ## Prerequisites
 
 - [Buck2](https://buck2.build/docs/getting_started/)
 - Go 1.27+
-- Docker, for the optional Floci AWS integration check
+- [Docker](https://docs.docker.com/), for the optional
+  [Floci](https://floci.io/) AWS integration check
 
 ## Commands
 

--- a/README.md
+++ b/README.md
@@ -26,28 +26,48 @@ chat group.
 
 ## Architecture
 
-Telegram group chat statistics bot. Tracks message counts, produces rankings,
-and schedules off-work reports.
+The bot counts group messages, ranks speakers, and sends off-work reports.
 
-Go HTTP webhook, Prometheus metrics, SQS worker, Telegram, and DynamoDB.
-The webhook server binds to port 3000 by default. The metrics server exposes
-`/metrics` on port 9090. Kubernetes uses `/health` for readiness. Code is in
-`cmd/` and `internal/`. Buck2 builds and tests.
+```mermaid
+flowchart LR
+    telegram[Telegram] --> http[HTTP :3000]
+    http --> dynamodb[DynamoDB]
+    http --> sqs[SQS]
+    scheduler[Scheduler] --> http
+    sqs --> worker[Worker]
+    worker --> dynamodb
+    worker --> telegram
+    worker --> sqs
+    prometheus[Prometheus] --> metrics[Metrics :9090]
+```
 
-`/metrics` includes Go and process data plus these service metrics:
+| Process | Address | Role                                     |
+|---------|---------|------------------------------------------|
+| HTTP    | `:3000` | Webhook, `/health`, and scheduler routes |
+| Metrics | `:9090` | `/metrics`                               |
+| Worker  |         | SQS actions                              |
 
-- Lifecycle: `telegram_jung2_bot_ready`.
-- HTTP: `telegram_jung2_bot_http_requests_total`,
-  `telegram_jung2_bot_http_request_duration_seconds`, and
-  `telegram_jung2_bot_http_requests_in_flight`. HTTP metrics use fixed method,
-  status, and route labels.
-- Webhooks: `telegram_jung2_bot_webhook_updates_total` and
-  `telegram_jung2_bot_webhook_commands_enqueued_total`.
-- Worker: `telegram_jung2_bot_worker_actions_total` and
-  `telegram_jung2_bot_worker_action_duration_seconds`.
-- Dependencies and schedules: `telegram_jung2_bot_dependency_requests_total`,
-  `telegram_jung2_bot_dependency_request_duration_seconds`, and
-  `telegram_jung2_bot_off_work_reports_enqueued_total`.
+Code lives in `cmd/` and `internal/`. Buck2 builds and tests.
+
+### Metrics
+
+`/metrics` includes Go and process collectors plus:
+
+| Metric                                                   | Meaning                           |
+|----------------------------------------------------------|-----------------------------------|
+| `telegram_jung2_bot_ready`                               | Readiness                         |
+| `telegram_jung2_bot_http_requests_total`                 | HTTP requests                     |
+| `telegram_jung2_bot_http_request_duration_seconds`       | HTTP duration                     |
+| `telegram_jung2_bot_http_requests_in_flight`             | In-flight HTTP requests           |
+| `telegram_jung2_bot_webhook_updates_total`               | Webhook outcomes                  |
+| `telegram_jung2_bot_webhook_commands_enqueued_total`     | Commands queued                   |
+| `telegram_jung2_bot_worker_actions_total`                | Queue actions                     |
+| `telegram_jung2_bot_worker_action_duration_seconds`      | Queue action duration             |
+| `telegram_jung2_bot_dependency_requests_total`           | DynamoDB, SQS, and Telegram calls |
+| `telegram_jung2_bot_dependency_request_duration_seconds` | Outbound call duration            |
+| `telegram_jung2_bot_off_work_reports_enqueued_total`     | Scheduled report enqueue results  |
+
+HTTP metrics use fixed method, status, and route labels.
 
 ## Where is the JavaScript version?
 

--- a/README.md
+++ b/README.md
@@ -85,10 +85,11 @@ whilst keeping it running until no one is using it.
 
 ## Prerequisites
 
-- [Buck2](https://buck2.build/docs/getting_started/)
+- Buck2
 - Go 1.27+
-- [Docker](https://docs.docker.com/), for the optional
-  [Floci](https://floci.io/) AWS integration check
+- [Apple Container](https://github.com/apple/container) for local images, or
+  [Docker](https://docs.docker.com/) if it is unavailable. Either covers the
+  optional [Floci](https://floci.io/) check
 
 ## Commands
 

--- a/README.md
+++ b/README.md
@@ -27,25 +27,8 @@ chat group.
 ## Architecture
 
 The bot counts group messages, ranks speakers, and sends off-work reports.
-
-Ingest:
-
-```mermaid
-flowchart LR
-    telegram[Telegram] --> http[HTTP :3000]
-    scheduler[Scheduler] --> http
-    http --> dynamodb[DynamoDB]
-    http --> sqs[SQS]
-```
-
-Work:
-
-```mermaid
-flowchart LR
-    sqs[SQS] --> worker[Worker]
-    worker --> dynamodb[DynamoDB]
-    worker --> telegram[Telegram]
-```
+Telegram and the scheduler hit HTTP. HTTP writes DynamoDB and enqueues SQS.
+The worker consumes SQS and calls DynamoDB and Telegram.
 
 | Process | Address | Role                                     |
 |---------|---------|------------------------------------------|

--- a/README.md
+++ b/README.md
@@ -28,17 +28,23 @@ chat group.
 
 The bot counts group messages, ranks speakers, and sends off-work reports.
 
+Ingest:
+
 ```mermaid
 flowchart LR
     telegram[Telegram] --> http[HTTP :3000]
+    scheduler[Scheduler] --> http
     http --> dynamodb[DynamoDB]
     http --> sqs[SQS]
-    scheduler[Scheduler] --> http
-    sqs --> worker[Worker]
-    worker --> dynamodb
-    worker --> telegram
-    worker --> sqs
-    prometheus[Prometheus] --> metrics[Metrics :9090]
+```
+
+Work:
+
+```mermaid
+flowchart LR
+    sqs[SQS] --> worker[Worker]
+    worker --> dynamodb[DynamoDB]
+    worker --> telegram[Telegram]
 ```
 
 | Process | Address | Role                                     |


### PR DESCRIPTION
## Summary
- rewrite `AGENTS.md` so local commands, mocks, and coverage sit in a table first
- keep the PR 3117 Apple Container fallback, contracts, and nested-worktree Buck2 rule
- rewrite the README architecture section as a flow diagram, process table, and metrics table

## Validation
- markdownlint-cli2 on `AGENTS.md` and `README.md`