### PR TITLE
fix(help): update /jungHelp copy and ranking names

### DIFF
--- a/internal/statistics.go
+++ b/internal/statistics.go
@@ -278,7 +278,7 @@ func HelpMessage(chatTitle string) string {
 
 冗員[jung2jyun4] Excess personnel in Cantonese
 
-This bot is created for counting the number of message per participant in the group.
+This bot is created for counting the number of messages per participant in the group.
 
 Commands:
 /topTen  show top ten 冗員s
@@ -287,12 +287,12 @@ Commands:
 /jungHelp  show help message
 
 Admin Only:
-/enableAllJung  enable `+"`/alljung`"+` command
-/disableAllJung  disable `+"`/alljung`"+` command
-/setOffFromWorkTimeUTC  set offFromWork time (UTC time)
+/enableAllJung  enable `+"`/allJung`"+` command
+/disableAllJung  disable `+"`/allJung`"+` command
+/setOffFromWorkTimeUTC  set UTC off-work time. E.g. 1800 MON,TUE,WED,THU,FRI
 
 [Bug Report/Suggestion](https://github.com/siutsin/telegram-jung2-bot/issues)
-[Service Status](https://stats.uptimerobot.com/kglZJSkYZg)
+[Service Status](https://www.webgazer.io/s?id=597)
 
 May your 冗 power powerful
 `, escapeMarkdownTitle(chatTitle))

--- a/internal/statistics.go
+++ b/internal/statistics.go
@@ -215,13 +215,16 @@ func buildDiverBody(summary rowSummary, options ReportOptions) string {
 
 // buildFooter builds the report footer text.
 // For example, totalMessage 20 becomes a footer starting with
-// "Total messages: 20".
+// "Total messages: 20". OffFromWork true appends the setOff footnote.
 func buildFooter(summary rowSummary, options ReportOptions) string {
 	footer := fmt.Sprintf("\nTotal messages: %d\n\n", summary.totalMessage)
 	if options.Reverse {
 		footer += "between, 深潛會搵唔到 ho chi is\n"
 	}
 	footer += fmt.Sprintf("Last Update: %s", options.Now.Format(updateTimestampLayout))
+	if options.OffFromWork {
+		footer += "\n\n---\nUse /setOffFromWorkTimeUTC to set the off-work time.\nSee /jungHelp for more info."
+	}
 	return footer
 }
 

--- a/internal/statistics.go
+++ b/internal/statistics.go
@@ -300,8 +300,18 @@ May your 冗 power powerful
 
 // displayName returns the preferred ranking display name.
 // For example, firstName "Ada" and lastName "Lovelace" become "Ada Lovelace".
+// firstName "Grace" or lastName "Hopper" alone become "Grace" or "Hopper".
+// Empty names with username "grace" or "@grace" become "grace".
 func displayName(row StoredMessage) string {
-	return strings.Join([]string{row.FirstName, row.LastName}, " ")
+	name := strings.TrimSpace(row.FirstName + " " + row.LastName)
+	if name != "" {
+		return name
+	}
+	username := strings.TrimPrefix(strings.TrimSpace(row.Username), "@")
+	if username != "" {
+		return username
+	}
+	return " "
 }
 
 // timeAgo formats a relative timestamp.

--- a/internal/statistics_test.go
+++ b/internal/statistics_test.go
@@ -60,6 +60,7 @@ func TestGenerateTopTenReport(t *testing.T) {
 	assert.Contains(t, summary.Report, "4. linus_t 16.67% (3 hours ago)")
 	assert.Contains(t, summary.Report, "Total messages: 6")
 	assert.Contains(t, summary.Report, "Last Update: 2026-05-02T12:00:00+00:00")
+	assert.NotContains(t, summary.Report, "/setOffFromWorkTimeUTC")
 	assert.NotContains(t, summary.Report, "5.")
 }
 
@@ -130,6 +131,7 @@ func TestGenerateOffFromWorkReport(t *testing.T) {
 
 	require.NoError(t, err)
 	assert.True(t, strings.HasPrefix(summary.Report, "夠鐘收工~~\n\n"))
+	assert.True(t, strings.HasSuffix(summary.Report, "\n\n---\nUse /setOffFromWorkTimeUTC to set the off-work time.\nSee /jungHelp for more info."))
 }
 
 func TestGenerateReportRejectsEmptyRows(t *testing.T) {

--- a/internal/statistics_test.go
+++ b/internal/statistics_test.go
@@ -16,15 +16,17 @@ func TestNormaliseRowsRanksByMessageCount(t *testing.T) {
 	rows := sampleRows()
 	normalised := normaliseRows(rows, false)
 
-	require.Len(t, normalised.rankings, 3)
-	assert.Equal(t, 5, normalised.totalMessage)
+	require.Len(t, normalised.rankings, 4)
+	assert.Equal(t, 6, normalised.totalMessage)
 	assert.Equal(t, int64(1), normalised.rankings[0].userID)
 	assert.Equal(t, 3, normalised.rankings[0].count)
 	assert.Equal(t, "Ada Lovelace", normalised.rankings[0].fullName)
 	assert.Equal(t, int64(2), normalised.rankings[1].userID)
-	assert.Equal(t, " ", normalised.rankings[1].fullName)
+	assert.Equal(t, "Grace Hopper", normalised.rankings[1].fullName)
 	assert.Equal(t, int64(3), normalised.rankings[2].userID)
-	assert.Equal(t, " ", normalised.rankings[2].fullName)
+	assert.Equal(t, "Alan", normalised.rankings[2].fullName)
+	assert.Equal(t, int64(4), normalised.rankings[3].userID)
+	assert.Equal(t, "linus_t", normalised.rankings[3].fullName)
 }
 
 func TestNormaliseRowsRanksDiversByLowMessageCount(t *testing.T) {
@@ -32,10 +34,11 @@ func TestNormaliseRowsRanksDiversByLowMessageCount(t *testing.T) {
 
 	normalised := normaliseRows(sampleRows(), true)
 
-	assert.Equal(t, []int64{2, 3, 1}, []int64{
+	assert.Equal(t, []int64{2, 3, 4, 1}, []int64{
 		normalised.rankings[0].userID,
 		normalised.rankings[1].userID,
 		normalised.rankings[2].userID,
+		normalised.rankings[3].userID,
 	})
 }
 
@@ -48,15 +51,16 @@ func TestGenerateTopTenReport(t *testing.T) {
 	})
 
 	require.NoError(t, err)
-	assert.Equal(t, 3, summary.UserCount)
-	assert.Equal(t, 5, summary.MessageCount)
+	assert.Equal(t, 4, summary.UserCount)
+	assert.Equal(t, 6, summary.MessageCount)
 	assert.Contains(t, summary.Report, "圍爐區: Group\n\nTop 10 冗員s in the last 7 days (last 上水 time):")
-	assert.Contains(t, summary.Report, "1. Ada Lovelace 60.00% (a day ago)")
-	assert.Contains(t, summary.Report, "2.   20.00% (2 days ago)")
-	assert.Contains(t, summary.Report, "3.   20.00% (a few seconds ago)")
-	assert.Contains(t, summary.Report, "Total messages: 5")
+	assert.Contains(t, summary.Report, "1. Ada Lovelace 50.00% (a day ago)")
+	assert.Contains(t, summary.Report, "2. Grace Hopper 16.67% (2 days ago)")
+	assert.Contains(t, summary.Report, "3. Alan 16.67% (a few seconds ago)")
+	assert.Contains(t, summary.Report, "4. linus_t 16.67% (3 hours ago)")
+	assert.Contains(t, summary.Report, "Total messages: 6")
 	assert.Contains(t, summary.Report, "Last Update: 2026-05-02T12:00:00+00:00")
-	assert.NotContains(t, summary.Report, "4.")
+	assert.NotContains(t, summary.Report, "5.")
 }
 
 // Reports are sent without parse_mode, so the title must survive verbatim.
@@ -90,7 +94,7 @@ func TestGenerateAllJungReport(t *testing.T) {
 
 	require.NoError(t, err)
 	assert.Contains(t, summary.Report, "All 冗員s in the last 14 days")
-	assert.Contains(t, summary.Report, "3.   20.00%")
+	assert.Contains(t, summary.Report, "4. linus_t 16.67%")
 }
 
 func TestGenerateTopDiverReport(t *testing.T) {
@@ -104,8 +108,8 @@ func TestGenerateTopDiverReport(t *testing.T) {
 
 	require.NoError(t, err)
 	assert.Contains(t, summary.Report, "Top 2 潛水員s in the last 7 days:")
-	assert.Contains(t, summary.Report, "By 冗power:\n1.   20.00%")
-	assert.Contains(t, summary.Report, "By last 上水:\n1.   - 2 days ago\n2. Ada Lovelace - a day ago")
+	assert.Contains(t, summary.Report, "By 冗power:\n1. Grace Hopper 16.67%")
+	assert.Contains(t, summary.Report, "By last 上水:\n1. Grace Hopper - 2 days ago\n2. Ada Lovelace - a day ago")
 	assert.Contains(t, summary.Report, "between, 深潛會搵唔到 ho chi is")
 	assert.NotContains(t, summary.Report, "3. Ada Lovelace 60.00%")
 }
@@ -189,8 +193,49 @@ func TestGenerateReportTruncatesAstralCharactersByJSLength(t *testing.T) {
 func TestDisplayNameMatchesContractJoinBehaviour(t *testing.T) {
 	t.Parallel()
 
-	assert.Equal(t, " grace", displayName(StoredMessage{LastName: "grace"}))
-	assert.Equal(t, " ", displayName(StoredMessage{Username: "grace", UserID: 3}))
+	tests := []struct {
+		name string
+		row  StoredMessage
+		want string
+	}{
+		{
+			name: "first and last",
+			row:  StoredMessage{FirstName: "Ada", LastName: "Lovelace"},
+			want: "Ada Lovelace",
+		},
+		{
+			name: "first name only",
+			row:  StoredMessage{FirstName: "Grace"},
+			want: "Grace",
+		},
+		{
+			name: "last name only",
+			row:  StoredMessage{LastName: "Hopper"},
+			want: "Hopper",
+		},
+		{
+			name: "username only",
+			row:  StoredMessage{Username: "grace", UserID: 3},
+			want: "grace",
+		},
+		{
+			name: "username with at sign",
+			row:  StoredMessage{Username: "@grace"},
+			want: "grace",
+		},
+		{
+			name: "no name or username",
+			row:  StoredMessage{UserID: 3},
+			want: " ",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, test.want, displayName(test.row))
+		})
+	}
 }
 
 func TestBuildBodyWithLimitCountsCharactersInsteadOfBytes(t *testing.T) {
@@ -311,6 +356,8 @@ func sampleRows() []StoredMessage {
 		{
 			ChatTitle:   "Group",
 			UserID:      2,
+			FirstName:   "Grace",
+			LastName:    "Hopper",
 			Username:    "grace",
 			DateCreated: now().Add(-48 * time.Hour),
 		},
@@ -324,6 +371,7 @@ func sampleRows() []StoredMessage {
 		{
 			ChatTitle:   "Group",
 			UserID:      3,
+			FirstName:   "Alan",
 			DateCreated: now(),
 		},
 		{
@@ -332,6 +380,12 @@ func sampleRows() []StoredMessage {
 			FirstName:   "Ada",
 			LastName:    "Lovelace",
 			DateCreated: now().Add(-time.Hour),
+		},
+		{
+			ChatTitle:   "Group",
+			UserID:      4,
+			Username:    "linus_t",
+			DateCreated: now().Add(-3 * time.Hour),
 		},
 	}
 }

--- a/internal/statistics_test.go
+++ b/internal/statistics_test.go
@@ -248,18 +248,18 @@ func TestHelpMessage(t *testing.T) {
 	assert.Equal(t, "\n"+
 		"圍爐區: Group\n\n"+
 		"冗員[jung2jyun4] Excess personnel in Cantonese\n\n"+
-		"This bot is created for counting the number of message per participant in the group.\n\n"+
+		"This bot is created for counting the number of messages per participant in the group.\n\n"+
 		"Commands:\n"+
 		"/topTen  show top ten 冗員s\n"+
 		"/topDiver  show top ten 潛水員s (潛得太深會搵唔到)\n"+
 		"/allJung  show all 冗員s\n"+
 		"/jungHelp  show help message\n\n"+
 		"Admin Only:\n"+
-		"/enableAllJung  enable `/alljung` command\n"+
-		"/disableAllJung  disable `/alljung` command\n"+
-		"/setOffFromWorkTimeUTC  set offFromWork time (UTC time)\n\n"+
+		"/enableAllJung  enable `/allJung` command\n"+
+		"/disableAllJung  disable `/allJung` command\n"+
+		"/setOffFromWorkTimeUTC  set UTC off-work time. E.g. 1800 MON,TUE,WED,THU,FRI\n\n"+
 		"[Bug Report/Suggestion](https://github.com/siutsin/telegram-jung2-bot/issues)\n"+
-		"[Service Status](https://stats.uptimerobot.com/kglZJSkYZg)\n\n"+
+		"[Service Status](https://www.webgazer.io/s?id=597)\n\n"+
 		"May your 冗 power powerful\n",
 		helpMessage,
 	)


### PR DESCRIPTION
## Summary

- Update `/jungHelp` copy: `/allJung` casing, `messages`, a setOff example, and the WebGazer status link.
- Rank with first name, last name, or username without `@`.
- Add an off-work `/topTen` footnote for `/setOffFromWorkTimeUTC` and `/jungHelp`.

## Test plan

- [x] `make test`