### PR TITLE
fix(command): require word boundary after command name

### DIFF
--- a/internal/command.go
+++ b/internal/command.go
@@ -23,37 +23,37 @@ var commandDefinitions = []commandDefinition{
 	{
 		Name:   jungHelp,
 		Action: queue.Action{Name: queue.ActionJungHelp, Body: queue.BodyJungHelp},
-		Regex:  regexp.MustCompile(`(?i)/` + regexp.QuoteMeta(jungHelp)),
+		Regex:  regexp.MustCompile(`(?i)/` + regexp.QuoteMeta(jungHelp) + `\b`),
 	},
 	{
 		Name:   topTen,
 		Action: queue.Action{Name: queue.ActionTopTen, Body: queue.BodyTopTen},
-		Regex:  regexp.MustCompile(`(?i)/` + regexp.QuoteMeta(topTen)),
+		Regex:  regexp.MustCompile(`(?i)/` + regexp.QuoteMeta(topTen) + `\b`),
 	},
 	{
 		Name:   topDiver,
 		Action: queue.Action{Name: queue.ActionTopDiver, Body: queue.BodyTopDiver},
-		Regex:  regexp.MustCompile(`(?i)/` + regexp.QuoteMeta(topDiver)),
+		Regex:  regexp.MustCompile(`(?i)/` + regexp.QuoteMeta(topDiver) + `\b`),
 	},
 	{
 		Name:   allJung,
 		Action: queue.Action{Name: queue.ActionAllJung, Body: queue.BodyAllJung},
-		Regex:  regexp.MustCompile(`(?i)/` + regexp.QuoteMeta(allJung)),
+		Regex:  regexp.MustCompile(`(?i)/` + regexp.QuoteMeta(allJung) + `\b`),
 	},
 	{
 		Name:   enableAllJung,
 		Action: queue.Action{Name: queue.ActionEnableAllJung, Body: queue.BodyEnableAllJung},
-		Regex:  regexp.MustCompile(`(?i)/` + regexp.QuoteMeta(enableAllJung)),
+		Regex:  regexp.MustCompile(`(?i)/` + regexp.QuoteMeta(enableAllJung) + `\b`),
 	},
 	{
 		Name:   disableAllJung,
 		Action: queue.Action{Name: queue.ActionDisableAllJung, Body: queue.BodyDisableAllJung},
-		Regex:  regexp.MustCompile(`(?i)/` + regexp.QuoteMeta(disableAllJung)),
+		Regex:  regexp.MustCompile(`(?i)/` + regexp.QuoteMeta(disableAllJung) + `\b`),
 	},
 	{
 		Name:   setOffWorkTime,
 		Action: queue.Action{Name: queue.ActionSetOffWorkTime, Body: queue.BodySetOffWorkTime},
-		Regex:  regexp.MustCompile(`(?i)/` + regexp.QuoteMeta(setOffWorkTime)),
+		Regex:  regexp.MustCompile(`(?i)/` + regexp.QuoteMeta(setOffWorkTime) + `\b`),
 	},
 }
 

--- a/internal/command_test.go
+++ b/internal/command_test.go
@@ -66,14 +66,14 @@ func TestParseAll(t *testing.T) {
 			commands: []Command{{Name: topTen}},
 		},
 		{
-			name:     "deployed prefix match",
+			name:     "prefix match rejected",
 			text:     "/topTen123",
-			commands: []Command{{Name: topTen, Args: "123"}},
+			commands: []Command{},
 		},
 		{
-			name:     "deployed set off prefix match",
+			name:     "set off prefix match rejected",
 			text:     "/setOffFromWorkTimeUTC123 1830 MON",
-			commands: []Command{{Name: setOffWorkTime, Args: "1830 MON"}},
+			commands: []Command{},
 		},
 		{
 			name:     "mention stripped",


### PR DESCRIPTION
## Summary
- `/topten123` previously matched the `topTen` command because command
  regexes matched on prefix only.
- Add `\b` to each command regex so a command only matches on an exact
  name, an `@mention`, or trailing whitespace/end of string.
- Update the "deployed prefix match" contract tests to assert the
  prefix form is now rejected.

## Test plan
- [x] `make test`
- [x] `make coverage` (100% for `internal/`)