### PR TITLE
fix(queue): omit empty SQS attributes

### DIFF
--- a/internal/queue/action.go
+++ b/internal/queue/action.go
@@ -268,11 +268,15 @@ func messageBodyText(body json.RawMessage) string {
 }
 
 // buildSendMessageRequest converts an action into the contract SQS request shape.
-// For example, chatId "42" becomes a Number attribute, while action stays a
-// String attribute.
+// Empty optional attributes are omitted because SQS rejects them. For example,
+// chatId "42" becomes a Number attribute and lastName "" is omitted.
 func buildSendMessageRequest(queueURL string, action Action) SendMessageRequest {
 	attributes := make(map[string]SendMessageAttribute, len(action.Attributes))
 	for name, value := range action.Attributes {
+		if value == "" {
+			continue
+		}
+
 		dataType := "String"
 		if name == "chatId" || name == "userId" {
 			dataType = "Number"

--- a/internal/queue/action_test.go
+++ b/internal/queue/action_test.go
@@ -300,6 +300,7 @@ func TestContractBodiesRemainStable(t *testing.T) {
 	}
 }
 
+// TestBuildSendMessageRequest keeps optional empty Telegram fields out of SQS requests.
 func TestBuildSendMessageRequest(t *testing.T) {
 	action := Action{
 		Body: BodySetOffWorkTime,
@@ -308,6 +309,7 @@ func TestBuildSendMessageRequest(t *testing.T) {
 			"chatId":    "-123",
 			"userId":    "456",
 			"chatTitle": "Group",
+			"lastName":  "",
 		},
 	}
 
@@ -319,6 +321,7 @@ func TestBuildSendMessageRequest(t *testing.T) {
 	assert.Equal(t, SendMessageAttribute{DataType: "Number", StringValue: "-123"}, request.MessageAttributes["chatId"])
 	assert.Equal(t, SendMessageAttribute{DataType: "Number", StringValue: "456"}, request.MessageAttributes["userId"])
 	assert.Equal(t, SendMessageAttribute{DataType: "String", StringValue: "Group"}, request.MessageAttributes["chatTitle"])
+	assert.NotContains(t, request.MessageAttributes, "lastName")
 }
 
 type fakeSender struct {

--- a/internal/queue/batch_test.go
+++ b/internal/queue/batch_test.go
@@ -294,6 +294,9 @@ func TestBuildSendMessageBatchRequestPreservesFIFOFields(t *testing.T) {
 		Body:                   BodySaveMessage,
 		MessageGroupID:         "42",
 		MessageDeduplicationID: "42:7",
+		Attributes: map[string]string{
+			"lastName": "",
+		},
 	}})
 
 	require.Len(t, request.Entries, 1)


### PR DESCRIPTION
## Summary

- omit empty optional Telegram fields from SQS message attributes
- cover single and batch request construction

## Validation

- make test
- make coverage