### PR TITLE
fix(webhook): drop unused updateId attribute from message save

### DIFF
--- a/internal/httpserver/webhook.go
+++ b/internal/httpserver/webhook.go
@@ -58,7 +58,6 @@ func enqueueWebhookSave(ctx context.Context, updateID int64, telegramMessage bot
 			"chatTitle": telegramMessage.Chat.Title,
 			"messageId": strconv.FormatInt(telegramMessage.MessageID, 10),
 			"date":      strconv.FormatInt(telegramMessage.Date, 10),
-			"updateId":  strconv.FormatInt(updateID, 10),
 		},
 	}
 	if telegramMessage.From != nil {

--- a/internal/httpserver/webhook_test.go
+++ b/internal/httpserver/webhook_test.go
@@ -225,6 +225,23 @@ func TestHandleWebhookCarriesTelegramMessageIdentity(t *testing.T) {
 	assert.Equal(t, "123:789", mocks.messageActions[0].MessageDeduplicationID)
 }
 
+// TestHandleWebhookSaveActionFitsSQSAttributeLimit preserves the SQS hard
+// cap of ten message attributes per message. The queue producer adds one
+// more attribute ("enqueuedAt") before sending, so a fully populated
+// message-save action must carry nine or fewer of its own.
+func TestHandleWebhookSaveActionFitsSQSAttributeLimit(t *testing.T) {
+	t.Parallel()
+
+	const sqsMaxMessageAttributes = 10
+	mocks, dependencies := newMockDependencies(t)
+	mocks.expectSaveWebhookState()
+	got := handleWebhook(context.Background(), []byte(`{"update_id":789,"message":{"message_id":456,"date":1777723200,"chat":{"id":123,"title":"Group","type":"group"},"from":{"id":456,"username":"username","first_name":"first","last_name":"last"},"text":"hello"}}`), dependencies)
+
+	assert.Equal(t, 200, got.statusCode)
+	require.Len(t, mocks.messageActions, 1)
+	assert.LessOrEqual(t, len(mocks.messageActions[0].Attributes), sqsMaxMessageAttributes-1)
+}
+
 func TestEnqueueWebhookCommandIgnoresUnsupportedCommand(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary

- drop the unused `updateId` message attribute from the message-save action

## Why

Production incident: `jung2bot-6.1.2` (otaru PR #3149) hit SQS
`InvalidParameterValue: Number of message attributes [11] exceeds the
allowed maximum [10]` on every batch flush, for any sender with
`username`, `first_name`, and `last_name` all set. The webhook already
sends up to ten attributes (`action`, `chatId`, `chatTitle`, `messageId`,
`date`, `updateId`, `userId`, `username`, `firstName`, `lastName`), and the
queue producer stamps one more (`enqueuedAt`) before sending, taking the
total to eleven and failing every flush in a tight retry loop. Rolled back
to `6.1.0` in otaru PR #3150 while this fix lands.

`updateId` was written but never read back by
`internal/message_save_worker.go`; the FIFO deduplication ID already
carries it as `chatId:updateId`. Dropping it restores the one attribute of
headroom `enqueuedAt` needs.

## Validation

- `make test`
- `make coverage` (100% for `internal/`)
- new test: `TestHandleWebhookSaveActionFitsSQSAttributeLimit` asserts a
  fully populated message-save action stays at nine attributes, so it fits
  under SQS's ten-attribute cap once `enqueuedAt` is added