### PR TITLE
ci: restore standard Ubuntu runner

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -12,7 +12,7 @@ concurrency:
 
 jobs:
   changes:
-    runs-on: ubuntu-24.04-arm
+    runs-on: ubuntu-latest
     permissions:
       contents: read
     outputs:
@@ -40,10 +40,8 @@ jobs:
               - 'hack/**'
               - 'Dockerfile'
 
-  # Run on arm64. Buck2 latest cannot link Go 1.27 stdlib on linux/amd64:
-  # `sync/atomic: invalid reference to internal/runtime/atomic.Load`.
   lint:
-    runs-on: ubuntu-24.04-arm
+    runs-on: ubuntu-latest
     permissions:
       contents: read
     steps:
@@ -77,7 +75,7 @@ jobs:
   coverage:
     needs: changes
     if: needs.changes.outputs.code == 'true'
-    runs-on: ubuntu-24.04-arm
+    runs-on: ubuntu-latest
     permissions:
       contents: read
     steps:
@@ -107,7 +105,7 @@ jobs:
         run: make vendor && make coverage
 
   test:
-    runs-on: ubuntu-24.04-arm
+    runs-on: ubuntu-latest
     permissions:
       contents: read
     steps:
@@ -134,7 +132,7 @@ jobs:
   integration:
     needs: changes
     if: needs.changes.outputs.code == 'true'
-    runs-on: ubuntu-24.04-arm
+    runs-on: ubuntu-latest
     permissions:
       contents: read
     steps:

--- a/GOTCHA.md
+++ b/GOTCHA.md
@@ -1,0 +1,16 @@
+# Gotchas
+
+## Buck2 and Go 1.27
+
+Problem: Buck2 fails on linux/amd64 while it links `gobuckify`.
+
+Cause: Go 1.27 `sync/atomic` assembly calls `internal/runtime/atomic`. Buck2
+adds `go tool asm -std` only when the Go toolchain reports its version. Both
+the stock and custom system Go toolchains report no version.
+
+Solution: Set `assembler_flags = ["-std"]` in
+`toolchains/configurable_system_go_toolchain.bzl`. This local toolchain needs
+the setting until Buck2 provides a versioned system Go toolchain with a race
+option. The
+[upstream toolchain](https://github.com/facebook/buck2/commit/26d2b38fac60e298944fc351a60281522214bf49)
+does not provide either feature at this time.

--- a/toolchains/configurable_system_go_toolchain.bzl
+++ b/toolchains/configurable_system_go_toolchain.bzl
@@ -55,7 +55,9 @@ def _configurable_system_go_toolchain_impl(ctx):
         GoToolchainInfo(
             asan = ctx.attrs.asan,
             assembler = RunInfo(cmd_script(ctx.actions, "asm", cmd_args(go, "tool", "asm"), script_language)),
-            assembler_flags = [],
+            # Go 1.27 requires standard assembly mode.
+            # This toolchain has no version.
+            assembler_flags = ["-std"],
             build_tags = [],
             cgo = RunInfo(go_root.project(tool_prefix + "/cgo" + suffix)),
             compiler = RunInfo(cmd_script(ctx.actions, "compile", cmd_args(go, "tool", "compile"), script_language)),


### PR DESCRIPTION
Restore ubuntu-latest runners after the Buck2 and Go linker workaround.