### PR TITLE
ci: add safe Go dependency checks

### DIFF
--- a/.github/workflows/govulncheck.yaml
+++ b/.github/workflows/govulncheck.yaml
@@ -1,0 +1,33 @@
+name: Go Vulnerability Check
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+    branches: [master]
+  schedule:
+    - cron: '22 10 * * *'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  scan:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Set up Go
+        uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
+        with:
+          go-version-file: go.mod
+
+      - name: Scan for reachable vulnerabilities
+        uses: geomys/sandboxed-step@7d75eb49d17fdeeb3656b3a57d35932d205bcfb9 # v1.2.1
+        with:
+          run: |
+            GOFLAGS=-mod=mod go run golang.org/x/vuln/cmd/govulncheck@latest ./...

--- a/.github/workflows/latest-dependencies.yaml
+++ b/.github/workflows/latest-dependencies.yaml
@@ -30,7 +30,7 @@ jobs:
         with:
           run: |
             sudo apt-get update -qq
-            sudo apt-get install -y -qq clang
+            sudo apt-get install -y -qq clang lld
             ./hack/install-buck2.sh
             export PATH="$HOME/.cargo/bin:$PATH"
             # Keep unreviewed dependency updates out of production to limit supply chain risk.

--- a/.github/workflows/latest-dependencies.yaml
+++ b/.github/workflows/latest-dependencies.yaml
@@ -1,6 +1,9 @@
 name: Test Latest Dependencies
 
 on:
+  pull_request:
+    paths:
+      - '.github/workflows/latest-dependencies.yaml'
   schedule:
     - cron: '0 4 * * 0'
   workflow_dispatch:
@@ -32,4 +35,4 @@ jobs:
             # See https://words.filippo.io/dependabot/
             go get -u -t ./...
             make vendor
-            make test
+            make test-only

--- a/.github/workflows/latest-dependencies.yaml
+++ b/.github/workflows/latest-dependencies.yaml
@@ -1,0 +1,35 @@
+name: Test Latest Dependencies
+
+on:
+  schedule:
+    - cron: '0 4 * * 0'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Set up Go
+        uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
+        with:
+          go-version-file: go.mod
+
+      - name: Test latest dependencies
+        uses: geomys/sandboxed-step@7d75eb49d17fdeeb3656b3a57d35932d205bcfb9 # v1.2.1
+        with:
+          run: |
+            ./hack/install-buck2.sh
+            export PATH="$HOME/.cargo/bin:$PATH"
+            # Keep unreviewed dependency updates out of production to limit supply chain risk.
+            # See https://words.filippo.io/dependabot/
+            go get -u -t ./...
+            make vendor
+            make test

--- a/.github/workflows/latest-dependencies.yaml
+++ b/.github/workflows/latest-dependencies.yaml
@@ -29,6 +29,8 @@ jobs:
         uses: geomys/sandboxed-step@7d75eb49d17fdeeb3656b3a57d35932d205bcfb9 # v1.2.1
         with:
           run: |
+            sudo apt-get update -qq
+            sudo apt-get install -y -qq clang
             ./hack/install-buck2.sh
             export PATH="$HOME/.cargo/bin:$PATH"
             # Keep unreviewed dependency updates out of production to limit supply chain risk.

--- a/.github/workflows/latest-dependencies.yaml
+++ b/.github/workflows/latest-dependencies.yaml
@@ -12,7 +12,7 @@ permissions:
   contents: read
 
 jobs:
-  test:
+  test-latest:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout

--- a/renovate.json5
+++ b/renovate.json5
@@ -11,6 +11,23 @@
   rebaseWhen: 'behind-base-branch',
   packageRules: [
     {
+      description: 'Test Go module updates weekly instead of opening PRs',
+      matchManagers: [
+        'gomod',
+      ],
+      enabled: false,
+    },
+    {
+      description: 'Update GitHub Actions weekly in one PR',
+      matchManagers: [
+        'github-actions',
+      ],
+      schedule: [
+        '* 0-3 * * 0',
+      ],
+      groupName: 'GitHub Actions',
+    },
+    {
       matchPackageNames: [
         'go.uber.org/mock',
       ],


### PR DESCRIPTION
Stop Renovate from opening Go module PRs. Scan reachable vulns with govulncheck. Test the latest modules weekly in a gVisor sandbox so unreviewed bumps never reach production.

GitHub Actions updates stay on Renovate, grouped into one weekly PR.

Follows https://words.filippo.io/dependabot/