### PR TITLE
docs: add latest-dependencies workflow badge

### DIFF
--- a/.github/workflows/govulncheck.yaml
+++ b/.github/workflows/govulncheck.yaml
@@ -1,4 +1,4 @@
-name: Go Vulnerability Check
+name: govulncheck
 
 on:
   push:

--- a/.github/workflows/latest-dependencies.yaml
+++ b/.github/workflows/latest-dependencies.yaml
@@ -1,4 +1,4 @@
-name: Test Latest Dependencies
+name: Latest Dependencies
 
 on:
   pull_request:

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # telegram-jung2-bot
 
+[![Latest Dependencies](https://github.com/siutsin/telegram-jung2-bot/actions/workflows/latest-dependencies.yaml/badge.svg)](https://github.com/siutsin/telegram-jung2-bot/actions/workflows/latest-dependencies.yaml)
+
 Add the bot to your group at [@jung2_bot](https://bit.ly/github-jung2bot)
 
 **冗員**[jung2jyun4] Excess personnel in Cantonese

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # telegram-jung2-bot
 
 [![Latest Dependencies](https://github.com/siutsin/telegram-jung2-bot/actions/workflows/latest-dependencies.yaml/badge.svg)](https://github.com/siutsin/telegram-jung2-bot/actions/workflows/latest-dependencies.yaml)
+[![govulncheck](https://github.com/siutsin/telegram-jung2-bot/actions/workflows/govulncheck.yaml/badge.svg)](https://github.com/siutsin/telegram-jung2-bot/actions/workflows/govulncheck.yaml)
 
 Add the bot to your group at [@jung2_bot](https://bit.ly/github-jung2bot)
 


### PR DESCRIPTION
Show the weekly latest-deps job on the README. A red badge means an unreviewed module bump broke the suite.